### PR TITLE
Update roadmap

### DIFF
--- a/_goals/10_bokehjs.md
+++ b/_goals/10_bokehjs.md
@@ -1,7 +1,0 @@
----
-description: Develop BokehJS as a First-class JavaScript Library
----
-By and large none of the core contributors have been JS or front-end experts, and for some time the client side BokehJS library was an implementation detail.
-There is more interest to use BokehJS directly, and with attention from experienced front-end JS developers, BokehJS could integrate better with existing common web frameworks and tools than it currently does.
-This includes making much more accessible documentation for BokehJS itself.
-These improvements would also help increase the potential pool of core developers interested in maintaining BokehJS over the long run.

--- a/_goals/70_mathtext.md
+++ b/_goals/70_mathtext.md
@@ -1,5 +1,0 @@
----
-description: Built-in LaTeX / MathText Support
----
-Bokeh can display mathematical symbols and formulas by creating and using custom extensions.
-Users have expressed a desire for this capability to be more directly integrated, e.g to draw math text for axis or tick labels, without needing to resort to a custom extension.

--- a/_goals/93_timezone.md
+++ b/_goals/93_timezone.md
@@ -1,0 +1,6 @@
+---
+description: Timezone Support
+---
+Bokeh currently ignores timezone information when displaying and handling dates and times.
+It could be modified to handle timezones, which includes potentially different timezones on the
+server and in the browser, and daylight saving time changes.

--- a/_goals/96_client_server.md
+++ b/_goals/96_client_server.md
@@ -1,0 +1,9 @@
+---
+description: Pluggable Client-Server Communications
+---
+Bokeh uses Tornado and WebSockets for communication between the server and client, and bespoke
+code to serialize/deserialize messages.
+It would be beneficial to decouple Bokeh functionality from the communication implementation and
+allow others such as those based on Jupyter and ZeroMQ for example.
+This would require a review and specification of the required communcation and serialization
+functionality, and at least two pluggable implementations, one of which would be the current one.


### PR DESCRIPTION
Updates to the roadmap.

I've removed the MathText and BokehJS sections as they are either done or about to be done. Possibly the "Technical Writing Assistance" should also be removed but I will leave that to @tcmetzger to decide. I've also added new items on Timezone Support and Pluggable Client-Server Communications. I don't have a strong view on whether they should be here or not, they are issues that have been talked about occasionally over the last few years and might be of wider interest.

Possibly interested parties: @bokeh/core, @Azaya89, @gabalafou.